### PR TITLE
chore: .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 # These files should have specific line endings
 # https://help.github.com/articles/dealing-with-line-endings/
-*.sh	text eol=lf
-*.bat	text eol=crlf
+*.sh  text eol=lf
+*.bat text eol=crlf
 
 # Prevent analysis of language on those folders
 .husky/** linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# These files should have specific line endings
+# https://help.github.com/articles/dealing-with-line-endings/
+*.sh	text eol=lf
+*.bat	text eol=crlf
+
+# Prevent analysis of language on those folders
+.husky/** linguist-vendored
+.storybook/** linguist-vendored


### PR DESCRIPTION
Added `.gitattributes` file to the project, so Github can ignore some folders when displaying languages used. It also makes git handle `.bat and .sh` files in a recommended way, as this [doc](https://help.github.com/articles/dealing-with-line-endings/) says.